### PR TITLE
Remove peer dependencies that are also direct dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,11 +66,6 @@
         "typescript": "^4.4.4"
     },
     "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "@mui/icons-material": "^5.0.0",
-        "@mui/material": "^5.0.0",
-        "@mui/system": "^5.0.0",
         "react": "^17.0.1 || ^18.0.0",
         "react-dom": "^17.0.2 || ^18.0.0"
     }


### PR DESCRIPTION
Specifying a peer dependency that is also a direct dependency doesn't seem to make sense - the carousel will use the dependency as specified it's package.json.

The carousel also has direct imports on MUI, generally peer dependencies shouldn't be used directly